### PR TITLE
Add "hello world" example to the repository, and add Travis badge to show if it works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - node
+services:
+  - docker
+matrix:
+  include:
+  - env: IMAGE=trzeci/emscripten
+  - env: IMAGE=trzeci/emscripten-slim
+script:
+  - printf '#include <iostream>\nint main() { std::cout << "HELLO FROM '$IMAGE'" << std::endl; return 0; }' > hello.cpp
+  - docker run --rm -v $(pwd):/src $IMAGE emcc hello.cpp -o hello.js
+  - node hello.js

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 This repository contains source files for Docker Hub projects:
 
 ## trzeci/emscripten-slim
-[![Docker Pulls](https://img.shields.io/docker/pulls/trzeci/emscripten-slim.svg)](https://store.docker.com/community/images/trzeci/emscripten-slim/) [![Size](https://images.microbadger.com/badges/image/trzeci/emscripten-slim.svg)](https://microbadger.com/images/trzeci/emscripten-slim/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/trzeci/emscripten-slim.svg)](https://store.docker.com/community/images/trzeci/emscripten-slim/)
+[![Size](https://images.microbadger.com/badges/image/trzeci/emscripten-slim.svg)](https://microbadger.com/images/trzeci/emscripten-slim/)
+[![Sanity](https://badges.herokuapp.com/travis/Quuxplusone/emscripten-docker?env=IMAGE=trzeci/emscripten-slim&label=hello)](https://travis-ci.org/Quuxplusone/emscripten-docker)
 
 * **Docker Hub**: https://hub.docker.com/r/trzeci/emscripten-slim/
 * **ReadMe**: https://github.com/asRIA/emscripten-docker/blob/master/emscripten-slim.md
 
 ## trzeci/emscripten
-[![Docker Pulls](https://img.shields.io/docker/pulls/trzeci/emscripten.svg)](https://store.docker.com/community/images/trzeci/emscripten/) [![Size](https://images.microbadger.com/badges/image/trzeci/emscripten.svg)](https://microbadger.com/images/trzeci/emscripten/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/trzeci/emscripten.svg)](https://store.docker.com/community/images/trzeci/emscripten/)
+[![Size](https://images.microbadger.com/badges/image/trzeci/emscripten.svg)](https://microbadger.com/images/trzeci/emscripten/)
+[![Sanity](https://badges.herokuapp.com/travis/Quuxplusone/emscripten-docker?env=IMAGE=trzeci/emscripten&label=hello)](https://travis-ci.org/Quuxplusone/emscripten-docker)
 
 * **Docker Hub**: https://hub.docker.com/r/trzeci/emscripten/
 * **ReadMe**: https://github.com/asRIA/emscripten-docker/blob/master/emscripten.md


### PR DESCRIPTION
The instructions given publicly at https://kripken.github.io/emscripten-site/docs/compiling/Travis.html don't actually work for me; I can't make `docker run ... docker exec` work no matter what I try.
But using `docker run` without `docker exec` (and leaving off the `-u emscripten`), I did manage to get a "hello world" program compiling!

I would like to see something like this added to the repository, so that people can see how the Docker image is intended to be used. (And also to protect against bit-rot: if the intended way to invoke "hello world" ever changes again, then the changes must be documented in `.travis.yml` or else the badge will go red. This is a good thing.)

This pull request shouldn't be merged directly, because of https://github.com/travis-ci/travis-ci/issues/779 , but I hope it's useful nonetheless.

You can see these TravisCI badges in action at
https://github.com/Quuxplusone/emscripten-docker/tree/master#trzeciemscripten-slim
As of this writing, they are both green.