### PR TITLE
Resolve a build error in the emscripten-fastcomp image

### DIFF
--- a/docker/trzeci/emscripten-fastcomp/Dockerfile
+++ b/docker/trzeci/emscripten-fastcomp/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stretch AS stage_build
 
 # ATM 1.38.40+ is supported, older will fail with missing /b/s/w/ir/k/install/fastcomp/bin/llc
 ARG EMSCRIPTEN_VERSION=1.38.43
-ARG EMSCRIPTEN_SDK=${EMSCRIPTEN_VERSION}
+ARG EMSCRIPTEN_SDK=${EMSCRIPTEN_VERSION}-fastcomp
 ARG EMSDK_CHANGESET=master
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
emsdk switched the default backend from 'fastcomp' to 'upstream' with:
emscripten-core/emsdk@ae5044e

This causes a build error within the emscripten-fastcomp Docker image,
since the '-fastcomp' suffix wasn't explicitly added.

This PR fixes #56.